### PR TITLE
Update environment.yml to fix jinja2 import issue

### DIFF
--- a/golden_scenario_env.yml
+++ b/golden_scenario_env.yml
@@ -14,3 +14,4 @@ dependencies:
   - pydotplus=2.0.2
   - keras=2.3.1
   - scikit-learn=0.24.2
+  - jinja2<3.1.0


### PR DESCRIPTION
Received import error for jinja2 escape when running titanic notebook. Suggested fix is to downgrade the jinja2 version, since changes were made in March to remove this function. Found this via the second answer on this [stackoverflow](https://stackoverflow.com/questions/71718167/importerror-cannot-import-name-escape-from-jinja2)